### PR TITLE
Document absence of GPT-5 Pro API

### DIFF
--- a/gpt5_pro_api.md
+++ b/gpt5_pro_api.md
@@ -1,0 +1,15 @@
+# GPT-5 Pro APIが存在しない理由
+
+## 背景
+- 2023年4月、OpenAIのCEO Sam Altmanは「GPT-5のトレーニングは行っておらず、しばらく予定もない」と述べたと報じられています[The Verge](https://www.theverge.com/2023/4/14/23685096/openai-gpt-5-training-sam-altman)。
+- 2024年にはGPT-4ファミリーの改良版としてGPT-4oが発表され、OpenAIは既存モデルの強化を継続しています[OpenAI Blog](https://openai.com/index/hello-gpt-4o/)。
+
+## 理由
+1. **未リリース**: GPT-5自体が公開されていないため、"GPT-5 Pro"と呼べるAPIも存在しません。
+2. **開発方針**: OpenAIは安全性と信頼性を重視し、より慎重な開発プロセスを進めています。
+3. **製品ラインの拡張**: GPT-4oなどの派生モデルが順次登場しており、当面はGPT-4系の改善が中心です。
+4. **安全性・倫理**: 強力なモデルの急速な公開より、社会的影響を考慮した段階的な導入を優先しています。
+
+## 参考リンク
+- [Sam Altman: OpenAI is not training GPT-5 and won't for some time – The Verge](https://www.theverge.com/2023/4/14/23685096/openai-gpt-5-training-sam-altman)
+- [Hello GPT-4o – OpenAI Blog](https://openai.com/index/hello-gpt-4o/)


### PR DESCRIPTION
## Summary
- Add Markdown file describing why a "GPT-5 Pro" API does not exist, citing public statements and current model focus.

## Testing
- `npm test` (fails: package.json not found)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6b584af2c8331b6f959780de387e3